### PR TITLE
OMEMO Media sharing: add link to XEP, not ProtoXEP

### DIFF
--- a/atalk/index.html
+++ b/atalk/index.html
@@ -72,7 +72,7 @@
 			  or <a href="https://otr.cypherpunks.ca/">OTR</a></li>
       <li><a href="./faq.html#account_03">SSL Certificate authentication, DNSSEC and DANE Security</a> implementation for enhanced secure Connection Establishment</li>
       <li>OMEMO encryption in group chat session enhancing privacy and security</li>
-      <li><a href="https://xmpp.org/extensions/inbox/omemo-media-sharing.html">OMEMO Media File Sharing</a> for all files including Stickers, Bitmoji and Emoji rich contents</li>
+      <li><a href="https://xmpp.org/extensions/xep-0454.html">OMEMO Media File Sharing</a> for all files including Stickers, Bitmoji and Emoji rich contents</li>
       <li>Support <a href="https://xmpp.org/extensions/xep-0363.html">HTTP File Upload</a> for file sharing with offline contact and in group chat</li>
       <li>Support <a href="./faq.html#feature_04">Stickers, Bitmoji and Emoji</a> rich content sharing via Google Gboard</li>
       <li>Send and receive files for all document types and images, with thumbnail preview and gif animation</li>


### PR DESCRIPTION
Line endings were automatically fixed by GitHub with the following message: 

> We’ve detected the file has mixed line endings. When you commit changes we will normalize them to Windows-style (CRLF).